### PR TITLE
fix script name + more meaningful option example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,14 +45,16 @@ Imagine we have a python package ``foo`` with the following ``setup.py``:
         },
     )
 
-We could use pytest-console-scripts to test the ``foo`` script:
+We could use pytest-console-scripts to test the ``foobar`` script:
 
 .. code-block:: python
 
     def test_foo_bar(script_runner):
-        ret = script_runner.run('foo', 'bar')
+        ret = script_runner.run('foobar', '--version')
         assert ret.success
-        assert ret.stdout == 'bar\n'
+        # just for example, let's assume that foobar --version 
+        # should output 3.2.1
+        assert ret.stdout == '3.2.1\n'
         assert ret.stderr == ''
 
 This would use the ``script_runner`` fixture provided by the plugin to


### PR DESCRIPTION
The script name is changed to `foobar`, in agreement with the declaration in `console_scripts`.
And `bar` was used both for the function called in the script and the optional argument.
To clarify, the optional argument is changed to `--version`, which might be more clearly identified.

Thanks a lot for this plugin, worked perfectly !
