### PR TITLE
Fix #19: Improve command path search

### DIFF
--- a/pytest_console_scripts.py
+++ b/pytest_console_scripts.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import distutils.spawn
 import io
 import os
 import subprocess
@@ -105,7 +106,7 @@ class ScriptRunner(object):
 
     def run_inprocess(self, command, *arguments, **options):
         cmdargs = [command] + list(arguments)
-        script = py.path.local(sys.executable).join('..', command)
+        script = py.path.local(distutils.spawn.find_executable(command))
         stdin = options.get('stdin', StreamMock())
         stdout = StreamMock()
         stderr = StreamMock()


### PR DESCRIPTION
The in-process execution assumed it could find a module's scripts in the
same location as the Python interpreter. However, when installing a
module system-wide, many distros install the scripts to a different path
than the interpreter, e.g. `/usr/local/bin` instead of `/usr/bin`.

Instead, use `distutils.spawn.find_executable` to find the path to the
requested script. In addition to searching the system path, this method
can also find executables relative to the working directory (in this
case, the path from which pytest is invoked).

`distutils.spawn.find_executable` is present in Python >=2.6 and >=3.0.