### PR TITLE
Create dist-packages directory inside test virtualenv on Debian

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ setup(
         ],
     },
     test_suite='tests',
-    tests_require=['pytest'],
+    tests_require=['pytest', 'virtualenv', 'mock'],
 )


### PR DESCRIPTION
Fix #21.

Here we create `dist-packages` when we run on Debian so installing small test package into it works and the tests don't fail.