### PR TITLE
Parametrize script runner with `indirect=True`

### DIFF
--- a/pytest_console_scripts.py
+++ b/pytest_console_scripts.py
@@ -80,9 +80,9 @@ def pytest_generate_tests(metafunc):
     mode = mark_mode or option_mode or config_mode or 'inprocess'
 
     if mode in {'inprocess', 'subprocess'}:
-        metafunc.parametrize('script_launch_mode', [mode])
+        metafunc.parametrize('script_launch_mode', [mode], indirect=True)
     elif mode == 'both':
-        metafunc.parametrize('script_launch_mode', ['inprocess', 'subprocess'])
+        metafunc.parametrize('script_launch_mode', ['inprocess', 'subprocess'], indirect=True)
     else:
         raise ValueError('Invalid script launch mode: {}'.format(mode))
 


### PR DESCRIPTION
This change is needed for pytest 5.4.0

c.f. https://github.com/pytest-dev/pytest/issues/5712