### PR TITLE
Update the tests and make them compatible with virtualenv v.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@
 sudo: false
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
+  - "3.7"
+  - "3.8"
+  - "pypy3"
 
 install:
   - pip install tox

--- a/pytest_console_scripts.py
+++ b/pytest_console_scripts.py
@@ -146,7 +146,10 @@ class ScriptRunner(object):
 
     def run_inprocess(self, command, *arguments, **options):
         cmdargs = [command] + list(arguments)
-        script = py.path.local(distutils.spawn.find_executable(command))
+        script_path = distutils.spawn.find_executable(command)
+        if script_path is None:
+            raise FileNotFoundError('Cannot execute ' + command)
+        script = py.path.local(script_path)
         stdin = options.get('stdin', StreamMock())
         stdout = StreamMock()
         stderr = StreamMock()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,15 @@
 # For more information about tox, see https://tox.readthedocs.org/en/latest/
 [tox]
-envlist = py27,py34,py35,py36,py37,pypy
+envlist = py35,py36,py37,py38,pypy3
+
+[testenv:py35]
+# We have to pin zipp and mock because newer versions require Python 3.6.
+deps =
+    pytest
+    virtualenv
+    zipp<2.0.0
+    mock<4.0.0
+commands = pytest tests
 
 [testenv]
 deps =


### PR DESCRIPTION
The tests broke because Python 2 is no longer supported, some test dependencies don't work in Python 3.5 and Virtualenv package changed its API and behavior so that the other versions also broke.