### PR TITLE
Use pkg_resources entry point loading - fix #37

### DIFF
--- a/pytest_console_scripts.py
+++ b/pytest_console_scripts.py
@@ -3,13 +3,13 @@ from __future__ import unicode_literals, print_function
 import io
 import logging
 import os
+import pkg_resources
 import shutil
 import subprocess
 import sys
 import traceback
 
 import mock
-import py.path
 import pytest
 
 if sys.version_info.major == 2:
@@ -169,13 +169,29 @@ class ScriptRunner(object):
 
         raise FileNotFoundError('Cannot find ' + command)
 
+    def _load_script(self, command, **options):
+        """Load target script via entry points or compile/exec."""
+        entry_points = list(pkg_resources.iter_entry_points('console_scripts',
+                                                            command))
+        if entry_points:
+            return entry_points[0].load()
+
+        script_path = self._locate_script(command, **options)
+
+        def exec_script():
+            with open(script_path, 'rt', encoding='utf-8') as script:
+                compiled = compile(script.read(), str(script), 'exec', flags=0)
+                exec(compiled, {'__name__': '__main__'})
+            return 0
+
+        return exec_script
+
     def run_inprocess(self, command, *arguments, **options):
         cmdargs = [command] + list(arguments)
-        script = py.path.local(self._locate_script(command, **options))
+        script = self._load_script(command, **options)
         stdin = options.get('stdin', StreamMock())
         stdout = StreamMock()
         stderr = StreamMock()
-        returncode = 0
         stdin_patch = mock.patch('sys.stdin', new=stdin)
         stdout_patch = mock.patch('sys.stdout', new=stdout)
         stderr_patch = mock.patch('sys.stderr', new=stderr)
@@ -191,8 +207,7 @@ class ScriptRunner(object):
             os.chdir(options['cwd'])
         with stdin_patch, stdout_patch, stderr_patch, argv_patch:
             try:
-                compiled = compile(script.read(), str(script), 'exec', flags=0)
-                exec(compiled, {'__name__': '__main__'})
+                returncode = script()
             except SystemExit as exc:
                 returncode = exc.code
                 if isinstance(returncode, str):

--- a/pytest_console_scripts.py
+++ b/pytest_console_scripts.py
@@ -208,6 +208,8 @@ class ScriptRunner(object):
         with stdin_patch, stdout_patch, stderr_patch, argv_patch:
             try:
                 returncode = script()
+                if returncode is None:
+                    returncode = 0  # None also means success.
             except SystemExit as exc:
                 returncode = exc.code
                 if isinstance(returncode, str):

--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -76,6 +76,23 @@ def test_script(script_runner):
     assert result.success
 
 
+@pytest.mark.script_launch_mode('inprocess')
+def test_return_None(script_runner):
+    """Check that entry point function returning None is counted as success."""
+
+    # Many console_scripts entry point functions return 0 on success but not
+    # all of them do. Returning `None` is also allowed and would be translated
+    # to return code 0 when run normally via wrapper. This test checks that we
+    # handle this case properly in inprocess mode.
+    #
+    # One commonly available script that returns None from the entry point
+    # function is easy_install so we use it here.
+
+    result = script_runner.run('easy_install', '-h')
+    assert result.success
+    assert '--verbose' in result.stdout
+
+
 @pytest.mark.script_launch_mode('both')
 def test_abnormal_exit(console_script, script_runner):
     console_script.write('import sys;sys.exit("boom")')


### PR DESCRIPTION
Idea by @brechtm ([patch](https://github.com/brechtm/pytest-console-scripts/commit/8ca02e8cf8f2bd84791c7d7b09c55a700a20649f)).

Here we combine both ways of script loading to (hopefully) make it work on Windows and also still work with not installed scripts.