### PR TITLE
Add option to suppress printing script run results - fix #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,35 @@ command line option that in turn overrides the configuration setting. All three
 can take three possible values: "inprocess", "subprocess", and "both" (which
 will cause the test to be run twice: in in-process and in subprocess modes).
 
+Suppressing the printing of script run results
+----------------------------------------------
+
+When tests involving `pytest-console-scripts` fail, it tends to be quite
+useful to see the output of the scripts that were executed in them. We try
+to be helpful and print it out just before returning the result from
+`script_runner.run()`. Normally PyTest [captures][12] all the output during a
+test run and it's not shown to the user unless some tests fail. This is exactly
+what we want.
+
+However, in some cases it might be useful to disable the output capturing and
+PyTest provides [ways to do it][13]. When capturing is disabled, all test run
+results will be printed out and this might make it harder to inspect the other
+output of the tests. To deal with this, `pytest-console-scripts` has an option
+to disable the printing of script run results:
+
+    $ pytest --hide-run-results test_foobar.py
+
+It's also possible to disable it just for one script run:
+
+    ret = script_runner.run('foobar', print_result=False)
+
+When printing of script run results is disabled, script output won't be
+visisble even when the test fails. Unfortunately there's no easy way to print
+it only if the test fails because by the time a script run completes we don't
+yet know whether the test will fail or not. In any case, with this option and
+capturing control we can configure what output gets displayed so it should be
+possible to get to the bottom of things.
+
 Package installation and testing during development
 ---------------------------------------------------
 
@@ -152,3 +181,5 @@ with [@hackebrot][5]'s [Cookiecutter-pytest-plugin][6] template.
 [9]: https://tox.readthedocs.org/en/latest/
 [10]: https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode
 [11]: https://docs.python.org/3/library/venv.html
+[12]: https://docs.pytest.org/en/stable/capture.html
+[13]: https://docs.pytest.org/en/stable/capture.html#setting-capturing-methods-or-disabling-capturing

--- a/tests/test_console_scripts.py
+++ b/tests/test_console_scripts.py
@@ -101,4 +101,5 @@ def test_help_message(testdir):
     result.stdout.fnmatch_lines([
         'console-scripts:',
         '*--script-launch-mode=*',
+        '*--hide-run-results*',
     ])

--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -40,7 +40,6 @@ def test_elsewhere_in_the_path(console_script, script_runner):
 
 @pytest.mark.script_launch_mode('both')
 def test_run_pytest(tmpdir, console_script, script_runner, launch_mode):
-    # TODO: check if same process or not!
     console_script.write('import os;print(os.getpid())')
     test = tmpdir.join('test_{}.py'.format(launch_mode))
     compare = '==' if launch_mode == 'inprocess' else '!='
@@ -229,3 +228,39 @@ print(os.path.basename('foo'))
     result = script_runner.run(str(console_script))
     assert result.success
     assert result.stdout == 'bar\n'
+
+
+def test_hide_run_result_arg(tmpdir, console_script, script_runner):
+    """Disable printing of the RunResult to stdout with print_result=False."""
+    console_script.write('print("42")')
+    test = tmpdir.join('test_hrra.py')
+    test.write(
+        """
+import pytest
+
+@pytest.mark.script_launch_mode('both')
+def test_script(script_runner):
+    script_runner.run('{}', print_result=False)
+        """.format(console_script)
+    )
+    result = script_runner.run('pytest', '-s', str(test))
+    assert result.success
+    assert '42' not in result.stdout
+
+
+def test_hide_run_result_opt(tmpdir, console_script, script_runner):
+    """Disable printing of the RunResult to stdout with print_result=False."""
+    console_script.write('print("42")')
+    test = tmpdir.join('test_hrro.py')
+    test.write(
+        """
+import pytest
+
+@pytest.mark.script_launch_mode('both')
+def test_script(script_runner):
+    script_runner.run('{}')
+        """.format(console_script)
+    )
+    result = script_runner.run('pytest', '-s', '--hide-run-results', str(test))
+    assert result.success
+    assert '42' not in result.stdout

--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -232,7 +232,7 @@ print(os.path.basename('foo'))
 
 def test_hide_run_result_arg(tmpdir, console_script, script_runner):
     """Disable printing of the RunResult to stdout with print_result=False."""
-    console_script.write('print("42")')
+    console_script.write('print("the answer is 42")')
     test = tmpdir.join('test_hrra.py')
     test.write(
         """
@@ -245,12 +245,13 @@ def test_script(script_runner):
     )
     result = script_runner.run('pytest', '-s', str(test))
     assert result.success
-    assert '42' not in result.stdout
+    assert 'the answer is 42' not in result.stdout
+    assert 'Running console script' not in result.stdout
 
 
 def test_hide_run_result_opt(tmpdir, console_script, script_runner):
     """Disable printing of the RunResult to stdout with print_result=False."""
-    console_script.write('print("42")')
+    console_script.write('print("the answer is 42")')
     test = tmpdir.join('test_hrro.py')
     test.write(
         """
@@ -263,4 +264,5 @@ def test_script(script_runner):
     )
     result = script_runner.run('pytest', '-s', '--hide-run-results', str(test))
     assert result.success
-    assert '42' not in result.stdout
+    assert 'the answer is 42' not in result.stdout
+    assert 'Running console script' not in result.stdout


### PR DESCRIPTION
This PR implements both the command line option (`--hide-run-results`) and the keyword argument for `script_runner.run()`. See README.md for more info.