### PR TITLE
Locate the Python interpreter through sys.executable

### DIFF
--- a/pytest_console_scripts.py
+++ b/pytest_console_scripts.py
@@ -262,7 +262,7 @@ class ScriptRunner(object):
         cmd_args = [command] + list(arguments)
         script_path = self._locate_script(command, **options)
         if _is_nonexecutable_python_file(script_path):
-            cmd_args = ['python'] + cmd_args
+            cmd_args = [sys.executable or 'python'] + cmd_args
 
         cp = subprocess.run(
             cmd_args,


### PR DESCRIPTION
While packaging for NixOS, I've found that running non-executable scripts depends on there being a `python` executable in the `$PATH`, which may not exist (aside from NixOS, Debian doesn't seem to have it by default either).

Instead, try to use the same executable as the current interpreter, and only if that is unknown do fallback to `python`.