### PR TITLE
Remove use of external mock

### DIFF
--- a/pytest_console_scripts.py
+++ b/pytest_console_scripts.py
@@ -9,17 +9,10 @@ import subprocess
 import sys
 import traceback
 
-import mock
+from unittest import mock
 import pytest
 
-if sys.version_info.major == 2:
-    # We can't use io.StringIO for mocking stdout/stderr in Python 2
-    # because printing byte strings to it triggers unicode errors and
-    # there's code in stdlib that does that (e.g. traceback module).
-    import StringIO
-    StreamMock = StringIO.StringIO
-else:
-    StreamMock = io.StringIO
+StreamMock = io.StringIO
 
 
 def pytest_addoption(parser):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=read('README.md'),
     long_description_content_type='text/markdown',
     py_modules=['pytest_console_scripts'],
-    install_requires=['pytest>=4.0.0', 'mock>=2.0.0'],
+    install_requires=['pytest>=4.0.0'],
     python_requires='>=3.6',
     setup_requires=['setuptools-scm'],
     classifiers=[


### PR DESCRIPTION
As of Python 3.3, mock has been included in the standard library, and in
fact, the test code makes use of that fact. However, the main plugin did
not, so remove its usage, and drop it from setup.py. Also clean up the
definition of StreamMock to boot.