### PR TITLE
Drop end-of-life Python 3.6 and fix CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.7", "3.8", "3.9", "pypy3.9"]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ same) when run by a fresh interpreter.
 Requirements
 ------------
 
-- Python 3.6+, or PyPy3,
+- Python 3.7+, or PyPy3,
 - Pytest 4.0 or newer.
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description_content_type='text/markdown',
     py_modules=['pytest_console_scripts'],
     install_requires=['pytest>=4.0.0'],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     setup_requires=['setuptools-scm'],
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -31,7 +31,6 @@ setup(
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,9 @@ deps =
     flake8-docstrings
     flake8-commas
     pep8-naming
-    twine
 
 commands =
     check-manifest --ignore *.ini,tests*,.*.yml,demo*
-    twine check .tox/dist/*
     flake8 pytest_console_scripts.py setup.py tests
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.org/en/latest/
 [tox]
-envlist = py36,py37,py38,py39,pypy3,lint
+envlist = py37,py38,py39,pypy3,lint
 
 [testenv]
 deps = pytest
@@ -30,8 +30,7 @@ ignore = W503,W504
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39,lint
-    pypy3: pypy3
+    pypy3.9: pypy3


### PR DESCRIPTION
This project was left unattended for quite a while.  `setuptools-scm` requires 3.7 now.  Since it's at EOL it's better to drop support for 3.6 than make a workaround.  Even Python 3.7 is only has a month left of support.  https://endoflife.date/python

There was a Twine check for the files at `.tox/dist/*` but these files don't exist causing the check to fail.  I don't know the details of Tox but I assume they've moved between versions.

Removing the Twine check, dropping 3.6, and updating the workflows was enough to get CI working again.