### PR TITLE
Add type-hinting, newer Python versions, and test on Windows.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,11 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "pypy3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.9"]
+        os: ["ubuntu-latest", "windows-latest"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pytest_console_scripts.py
+++ b/pytest_console_scripts.py
@@ -281,6 +281,13 @@ class ScriptRunner:
         if _is_nonexecutable_python_file(script_path):
             cmd_args = [sys.executable or 'python'] + cmd_args
 
+        env: dict[str, str] | None = options.get("env")
+        # Prevent _Py_HashRandomization_Init failure on Windows
+        if env is not None and "SYSTEMROOT" in os.environ:
+            env = env.copy()
+            env.setdefault("SYSTEMROOT", os.environ["SYSTEMROOT"])
+            options["env"] = env
+
         cp = subprocess.run(
             cmd_args,
             input=stdin_input,

--- a/pytest_console_scripts.py
+++ b/pytest_console_scripts.py
@@ -281,13 +281,6 @@ class ScriptRunner:
         if _is_nonexecutable_python_file(script_path):
             cmd_args = [sys.executable or 'python'] + cmd_args
 
-        env: dict[str, str] | None = options.get("env")
-        # Prevent _Py_HashRandomization_Init failure on Windows
-        if env is not None and "SYSTEMROOT" in os.environ:
-            env = env.copy()
-            env.setdefault("SYSTEMROOT", os.environ["SYSTEMROOT"])
-            options["env"] = env
-
         cp = subprocess.run(
             cmd_args,
             input=stdin_input,

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,8 @@
-import os
+from pathlib import Path
 from setuptools import setup
 
-
-def read(fname):
-    file_path = os.path.join(os.path.dirname(__file__), fname)
-    with open(file_path, encoding='utf-8') as f:
-        return f.read()
+THIS_DIR = Path(__file__).parent
+README_TEXT = (THIS_DIR / 'README.md').read_text(encoding='utf-8')
 
 
 setup(
@@ -18,7 +15,7 @@ setup(
     license='MIT',
     url='https://github.com/kvas-it/pytest-console-scripts',
     description='Pytest plugin for testing console scripts',
-    long_description=read('README.md'),
+    long_description=README_TEXT,
     long_description_content_type='text/markdown',
     py_modules=['pytest_console_scripts'],
     install_requires=['pytest>=4.0.0'],

--- a/tests/test_console_scripts.py
+++ b/tests/test_console_scripts.py
@@ -1,16 +1,17 @@
-from __future__ import print_function, unicode_literals
+from __future__ import annotations
 
 import pytest
 
 
 @pytest.fixture(params=[None, 'inprocess', 'subprocess', 'both'])
-def launch_mode_conf(request):
+def launch_mode_conf(request: pytest.FixtureRequest) -> str | None:
     """Configured launch mode (None|'inprocess'|'subprocess'|'both')."""
+    assert request.param is None or isinstance(request.param, str)
     return request.param
 
 
 @pytest.fixture
-def launch_modes(launch_mode_conf):
+def launch_modes(launch_mode_conf: str | None) -> set[str]:
     """Set of launch modes in which the tests will actually be run.
 
     The value of this fixture depends on the value of `launch_mode_conf`:
@@ -26,19 +27,32 @@ def launch_modes(launch_mode_conf):
     return {'inprocess'}
 
 
-@pytest.fixture
-def run_test(testdir):
-    def run(script, passed=1, skipped=0, failed=0, launch_mode_conf=None):
-        testdir.makepyfile(script)
+class RunTest:
+    def __init__(self, testdir: pytest.Testdir) -> None:
+        self.testdir = testdir
+
+    def __call__(
+        self,
+        script: str,
+        passed: int = 1,
+        skipped: int = 0,
+        failed: int = 0,
+        launch_mode_conf: str | None = None
+    ) -> pytest.RunResult:
+        self.testdir.makepyfile(script)
         args = []
         if launch_mode_conf is not None:
             args.append('--script-launch-mode=' + launch_mode_conf)
-        result = testdir.runpytest(*args)
+        result = self.testdir.runpytest(*args)
         print('\n'.join(['pytest stdout:'] + result.outlines +
                         ['pytest stderr:'] + result.errlines))
         result.assert_outcomes(passed=passed, skipped=skipped, failed=failed)
         return result
-    return run
+
+
+@pytest.fixture
+def run_test(testdir: pytest.Testdir) -> RunTest:
+    return RunTest(testdir)
 
 
 CHECK_LAUNCH_MODE = """
@@ -49,7 +63,9 @@ def test_both(script_runner, accumulator=set()):
 """
 
 
-def test_command_line_option(run_test, launch_mode_conf, launch_modes):
+def test_command_line_option(
+    run_test: RunTest, launch_mode_conf: str | None, launch_modes: set[str]
+) -> None:
     run_test(
         CHECK_LAUNCH_MODE.format(launch_modes),
         passed=len(launch_modes),
@@ -57,12 +73,17 @@ def test_command_line_option(run_test, launch_mode_conf, launch_modes):
     )
 
 
-def test_config_option(run_test, testdir, launch_mode_conf, launch_modes):
+def test_config_option(
+    run_test: RunTest,
+    testdir: pytest.Testdir,
+    launch_mode_conf: str | None,
+    launch_modes: set[str],
+) -> None:
     if launch_mode_conf is not None:
-        testdir.makeini("""
+        testdir.makeini(f"""
             [pytest]
-            script_launch_mode = {}
-        """.format(launch_mode_conf))
+            script_launch_mode = {launch_mode_conf}
+        """)
 
     run_test(
         CHECK_LAUNCH_MODE.format(launch_modes),
@@ -70,7 +91,9 @@ def test_config_option(run_test, testdir, launch_mode_conf, launch_modes):
     )
 
 
-def test_override_launch_mode_with_mark(run_test, launch_mode_conf):
+def test_override_launch_mode_with_mark(
+    run_test: RunTest, launch_mode_conf: str | None
+) -> None:
     run_test(
         """
 import pytest
@@ -93,7 +116,7 @@ def test_both(script_runner, accumulator=set()):
     )
 
 
-def test_help_message(testdir):
+def test_help_message(testdir: pytest.Testdir) -> None:
     result = testdir.runpytest(
         '--help',
     )

--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -118,6 +118,20 @@ sys.exit(None)
     assert 'Foo' in result.stdout
 
 
+@pytest.mark.script_launch_mode('inprocess')
+def test_return_code_uncommon(
+    console_script: Path, script_runner: ScriptRunner
+) -> None:
+    """Check uncommon return codes."""
+    console_script.write_text(
+        """
+import sys
+sys.exit(2)
+"""
+    )
+    assert script_runner.run(str(console_script)).returncode == 2
+
+
 @pytest.mark.script_launch_mode('both')
 def test_abnormal_exit(
     console_script: Path, script_runner: ScriptRunner

--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -98,29 +98,24 @@ def test_script(script_runner):
 
 
 @pytest.mark.script_launch_mode('inprocess')
-def test_return_None(script_runner: ScriptRunner) -> None:
+def test_return_None(
+    console_script: Path, script_runner: ScriptRunner
+) -> None:
     """Check that entry point function returning None is counted as success."""
-
     # Many console_scripts entry point functions return 0 on success but not
     # all of them do. Returning `None` is also allowed and would be translated
     # to return code 0 when run normally via wrapper. This test checks that we
     # handle this case properly in inprocess mode.
-    #
-    # One commonly available script that returns None from the entry point
-    # function is easy_install so we use it here.
-
-    try:
-        path = script_runner._locate_script('easy_install')
-        if os.path.join('.pyenv', 'shims') in path:
-            # We have a shell wrapper from pyenv instead of real easy_install.
-            return
-    except FileNotFoundError:
-        # No easy_install. We skip the test.
-        return
-
-    result = script_runner.run('easy_install', '-h')
+    console_script.write_text(
+        """
+import sys
+print("Foo")
+sys.exit(None)
+"""
+    )
+    result = script_runner.run(str(console_script))
     assert result.success
-    assert '--verbose' in result.stdout
+    assert 'Foo' in result.stdout
 
 
 @pytest.mark.script_launch_mode('both')

--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -48,7 +48,8 @@ def test_elsewhere_in_the_path(
     console_script: Path, script_runner: ScriptRunner
 ) -> None:
     console_script.chmod(0o777)
-    env = {'PATH': f"{console_script.parent}{os.pathsep}{os.environ['PATH']}"}
+    env = os.environ.copy()
+    env["PATH"] = f"{console_script.parent}{os.pathsep}{env['PATH']}"
     result = script_runner.run(console_script.name, env=env)
     assert result.success
     assert result.stdout == 'foo\n'
@@ -187,7 +188,9 @@ print(os.environ['FOO'])
 os.environ['FOO'] = 'baz'
         """
     )
-    result = script_runner.run(str(console_script), env={'FOO': 'bar'})
+    env = os.environ.copy()
+    env['FOO'] = 'bar'
+    result = script_runner.run(str(console_script), env=env)
     assert result.success
     assert result.stdout == 'bar\n'
     assert 'FOO' not in os.environ

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.org/en/latest/
 [tox]
-envlist = py37,py38,py39,pypy3,lint
+envlist = py37,py38,py39,py310,py311,pypy3,lint
 
 [testenv]
 deps = pytest
@@ -31,4 +31,6 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39,lint
+    3.10: py310
+    3.11: py311
     pypy3.9: pypy3

--- a/tox.ini
+++ b/tox.ini
@@ -16,10 +16,13 @@ deps =
     flake8-docstrings
     flake8-commas
     pep8-naming
+    mypy
+    types-setuptools
 
 commands =
     check-manifest --ignore *.ini,tests*,.*.yml,demo*
     flake8 pytest_console_scripts.py setup.py tests
+    mypy pytest_console_scripts.py setup.py tests
 
 [flake8]
 exclude = .tox,*.egg,build


### PR DESCRIPTION
Many tests were failing when run on Windows.  I have fixed them and marked the rest:
- Windows paths were being added to test code without being escaped correctly.
- Windows does not treat Python scripts as executables for `shutil.which`, so tests relying on this will fail.
- The Windows `SYSTEMROOT` environment variable is required to initialize Python correctly.  "subprocess" mode often crashes without it.  This has been fixed.
- `easy_install` has encoding issues on Windows. It's also missing from many environments so I've replaced the test using it with a custom script.

Updated some older pytest fixtures to newer ones. Most of the current fixtures have replacements and I skipped over a lot of them.

Added Mypy to Tox.  I've fully typed the code so that it passed `mypy --strict` but I didn't add `--strict` to the linting tests yet.

Added Python versions up to 3.11 to CI, also added Windows to CI.

I tested coverage, only two lines in `pytest_console_scripts.py` are missing from a Windows test.