### PR TITLE
Use importlib.metadata for entry points.

### DIFF
--- a/pytest_console_scripts.py
+++ b/pytest_console_scripts.py
@@ -11,8 +11,12 @@ from pathlib import Path
 from typing import Any, Callable
 from unittest import mock
 
-import pkg_resources
 import pytest
+
+if sys.version_info < (3, 10):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
 
 StreamMock = io.StringIO
 
@@ -192,8 +196,11 @@ class ScriptRunner:
         self, command: str, **options: Any
     ) -> Callable[[], int | None]:
         """Load target script via entry points or compile/exec."""
-        entry_points = list(pkg_resources.iter_entry_points('console_scripts',
-                                                            command))
+        entry_points = tuple(
+            importlib_metadata.entry_points(
+                group='console_scripts', name=command
+            )
+        )
         if entry_points:
             def console_script() -> int | None:
                 s: Callable[[], int | None] = entry_points[0].load()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ setup(
     long_description=README_TEXT,
     long_description_content_type='text/markdown',
     py_modules=['pytest_console_scripts'],
-    install_requires=['pytest>=4.0.0'],
+    install_requires=[
+        'pytest >=4.0.0',
+        "importlib_metadata >=3.6; python_version < '3.10'",
+    ],
     python_requires='>=3.7',
     setup_requires=['setuptools-scm'],
     classifiers=[

--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -351,7 +351,7 @@ class MockEntryPoint:
 def test_global_logging(
     tmp_path: Path, console_script: Path, script_runner: ScriptRunner
 ) -> None:
-    """Load global values when executing from pkg_resources"""
+    """Load global values when executing from importlib.metadata"""
     test = tmp_path / 'test_entry_point.py'
     test.write_text(
         """
@@ -368,8 +368,13 @@ def run() -> None:
         """
     )
 
+    if sys.version_info < (3, 10):
+        patched_func = 'importlib_metadata.entry_points'
+    else:
+        patched_func = 'importlib.metadata.entry_points'
+
     with mock.patch(
-        'pkg_resources.iter_entry_points',
+        patched_func,
         mock.MagicMock(return_value=[MockEntryPoint(str(test))]),
     ):
         result = script_runner.run(str(console_script))


### PR DESCRIPTION
Replaces the deprecated `pkg_resources` module, `setuptools` is no longer needed.  Fixes #56 

Uses the select API which needs a specific later version of the module. I did this in the fanciest way possible.  In Python 3.10 and later it imports from the standard library, otherwise it installs the fallback package from PyPI and uses that instead.