### PR TITLE
Trigger CI tests on push and on pull request activity.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,8 @@ name: Run the tests
 
 on:
   push:
-    branches:
-      - master
   pull_request:
+    types: [opened, reopened]
 
 jobs:
   build:


### PR DESCRIPTION
I like to use the CI to test my topic branches before making a PR for them, but I can't do that when push is restricted to the master branch.

Having both push and pull_request can cause updates to PR's to be run twice when updated.  Restricting the types reduces this.  Then if you ever need to manually trigger the test on a PR you can close and reopen that PR.