### PR TITLE
Add code coverage reports and upload them.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox
     - name: Test with tox
-      run: tox
+      run: tox run -e py,report_ci,lint
+    - uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: true

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,37 @@
 # For more information about tox, see https://tox.readthedocs.org/en/latest/
 [tox]
-envlist = py37,py38,py39,py310,py311,pypy3,lint
+envlist = clean,lint,py37,py38,py39,py310,py311,pypy3,report
 
 [testenv]
-deps = pytest
-commands = pytest tests
+deps =
+    pytest
+    pytest-cov
+usedevelop = true
+commands = pytest tests --cov=pytest_console_scripts --cov-append --cov-report=term-missing {posargs}
+depends =
+    {py37,py38,py39,py310,py311,pypy3}: clean
+    report: py37,py38,py39,py310,py311,pypy3
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report
+    coverage html
+
+[testenv:report_ci]
+deps = coverage
+skip_install = true
+commands = coverage xml
 
 [testenv:lint]
-basepython = python3.9
+basepython = python
+usedevelop = true
 
 deps =
     check-manifest
@@ -28,12 +52,3 @@ commands =
 exclude = .tox,*.egg,build
 select = E,W,F
 ignore = W503,W504
-
-[gh-actions]
-python =
-    3.7: py37
-    3.8: py38
-    3.9: py39,lint
-    3.10: py310
-    3.11: py311
-    pypy3.9: pypy3


### PR DESCRIPTION
Tox told to install the package in development mode to make a few things work such as test coverage paths.

Tox now reports code coverage using `pytest-cov`.  Closes #16

Using Codecov.io for no reason other than that I'm most familiar with it.  [You can see how it looks here](https://app.codecov.io/gh/HexDecimal/pytest-console-scripts/blob/coverage/pytest_console_scripts.py). There might be more to setup for this, you might have to enable `kvas-it/pytest-console-scripts` on [codecov.io](https://app.codecov.io/gh). I'll add a badge for this later.

I could not get `tox-gh-actions` working as well as I wanted. I ended up removing it and using the `py` env instead.  I can revert this if you want.  Linters are being run on all versions of Python in the CI, Mypy benefits from this but it could be handled better. This is mostly due to my inexperience with Tox.

Tox linting changed to use the active version of Python.