### PR TITLE
Refactor main fixture to act more like subprocess.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ We could use pytest-console-scripts to test the `foobar` script:
 
 ```py
 def test_foo_bar(script_runner):
-    ret = script_runner.run('foobar', '--version')
-    assert ret.success
-    assert ret.stdout == '3.2.1\n'
-    assert ret.stderr == ''
+    result = script_runner.run(['foobar', '--version'])
+    assert result.returncode == 0
+    assert result.stdout == '3.2.1\n'
+    assert result.stderr == ''
+
+    script_runner.run('foobar --version', shell=True, check=True)
 ```
 
 This would use the `script_runner` fixture provided by the plugin to
@@ -75,6 +77,9 @@ following keyword arguments can be used:
   environment.
 - `stdin` - a file-like object that will be piped to standard input of the
   script.
+- `check` - raises an exception if `returncode != 0`, defaults to False.
+- `shell` - mimic shell execution, this should work well for simple cases,
+  defaults to False.
 
 Type-hinting is also supported.
 You may type-hint the fixture with the following code:


### PR DESCRIPTION
Support sequence command arguments, deprecated old argument parameter. Added check keyword support, this acts almost exactly like subprocess including raising CalledProcessError. Added shell keyword, it should work for most simple cases. Also adds support for PathLike values in commands. New features are covered by tests.  Closes #63

Refactored methods in the ScriptRunner class.  Many functions are now staticmethod and classmethod, it's possible that these methods do not need to be in the class itself.

Refactored and added several context managers. run_inprocess now uses ExitStack to collect it's managers. stdout and stderr now use contextlib for redirects as mentioned in #24 which should make them more accurate.

Supported keywords were made into parameters. Unknown keywords in options will now raise a warning for `inprocess` mode.