### PR TITLE
Wrap PathLike's in a sequence on Python 3.7 for subprocess.run.

### DIFF
--- a/pytest_console_scripts/__init__.py
+++ b/pytest_console_scripts/__init__.py
@@ -412,6 +412,15 @@ class ScriptRunner:
             command = _handle_command_args(command, shell=shell)
             command = [sys.executable or 'python', *command]
 
+        if sys.version_info < (3, 8):
+            if isinstance(command, os.PathLike):
+                command = [command]
+            if not isinstance(command, str):
+                command = [
+                    str(Path(arg)) if isinstance(arg, os.PathLike) else arg
+                    for arg in command
+                ]
+
         cp = subprocess.run(
             command,
             input=stdin_input,

--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -463,3 +463,7 @@ def test_run_path(
     result = script_runner.run(console_script, check=True)
     assert result.stdout == 'foo\n'
     assert result.stderr == ''
+    console_script.chmod(0o777)
+    result = script_runner.run(console_script, check=True)
+    assert result.stdout == 'foo\n'
+    assert result.stderr == ''

--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -454,3 +454,12 @@ def test_disable_universal_newlines(
     assert isinstance(result.stderr, bytes)
     assert result.stdout.strip() == b'foo'
     assert result.stderr == b''
+
+
+@pytest.mark.script_launch_mode('both')
+def test_run_path(
+    console_script: Path, script_runner: ScriptRunner
+) -> None:
+    result = script_runner.run(console_script, check=True)
+    assert result.stdout == 'foo\n'
+    assert result.stderr == ''


### PR DESCRIPTION
`subprocess.run` can't take a `PathLike` directly until Python 3.8.