### PR TITLE
Add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 pytest-console-scripts
 ======================
 
+[![PyPI](https://img.shields.io/pypi/v/pytest-console-scripts)](https://pypi.org/project/pytest-console-scripts/)
+[![PyPI - License](https://img.shields.io/pypi/l/pytest-console-scripts)](https://github.com/kvas-it/pytest-console-scripts/blob/master/LICENSE)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/kvas-it/pytest-console-scripts/test.yml)](https://github.com/kvas-it/pytest-console-scripts/actions)
+[![codecov](https://codecov.io/gh/kvas-it/pytest-console-scripts/branch/master/graph/badge.svg?token=RfELxcqvpF)](https://codecov.io/gh/kvas-it/pytest-console-scripts)
+
+[![GitHub issues](https://img.shields.io/github/issues/kvas-it/pytest-console-scripts)](https://github.com/kvas-it/pytest-console-scripts/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/kvas-it/pytest-console-scripts)](https://github.com/kvas-it/pytest-console-scripts/pulls)
+[![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/kvas-it/pytest-console-scripts/latest)](https://github.com/kvas-it/pytest-console-scripts/commits/master)
+
 Pytest-console-scripts is a [pytest][1] plugin for running python scripts from
 within tests. It's quite similar to `subprocess.run()`, but it also has an
 in-process mode, where the scripts are executed by the interpreter that's


### PR DESCRIPTION
These are useful for quick information and navigation. Mostly useful as a way to get to the PyPI page from GitHub and then to the GitHub pages from the readme on PyPI.

- [x] @kvas-it, I don't have the permissions for the Codecov badge. You'll need to go here and give me the markdown badge, or at least the API token. https://app.codecov.io/gh/kvas-it/pytest-console-scripts/settings/badge

I've added the ones I'm interested in, you can see https://shields.io/ if you're curious about other options.

See the readme here for that these look like: https://github.com/HexDecimal/pytest-console-scripts/tree/add-badges