### PR TITLE
Fix loading scripts with non-UTF-8 encodings.

### DIFF
--- a/pytest_console_scripts/__init__.py
+++ b/pytest_console_scripts/__init__.py
@@ -313,9 +313,10 @@ class ScriptRunner:
         script_path = cls._locate_script(command, cwd=cwd, env=env)
 
         def exec_script() -> int:
-            with open(script_path, 'rt', encoding='utf-8') as script:
-                compiled = compile(script.read(), str(script), 'exec', flags=0)
-                exec(compiled, {'__name__': '__main__'})
+            compiled = compile(
+                script_path.read_bytes(), str(script_path), 'exec', flags=0
+            )
+            exec(compiled, {'__name__': '__main__'})
             return 0
 
         return exec_script

--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -465,3 +465,21 @@ def test_run_path(
     result = script_runner.run(console_script, check=True)
     assert result.stdout == 'foo\n'
     assert result.stderr == ''
+
+
+@pytest.mark.script_launch_mode('both')
+def test_run_script_codecs(
+    console_script: Path, script_runner: ScriptRunner
+) -> None:
+    """Check that non-UTF-8 scripts can load"""
+    console_script.write_text(
+        """\
+# -*- coding: cp437 -*-
+import sys  # Non UTF-8 characters -> ≡≡≡
+print('foo')
+        """,
+        encoding="cp437",
+    )
+    result = script_runner.run(console_script, check=True)
+    assert result.stdout == 'foo\n'
+    assert result.stderr == ''


### PR DESCRIPTION
I noticed an issue with the in-process script loader where some scripts would fail to load with encoding errors.

Instead of assuming that a script is UTF-8, a bytes string can be passed to `compile()` which will detect the encoding automatically.