### PR TITLE
Explicitly specify pytest subprocess rootdir

### DIFF
--- a/tests/test_run_scripts.py
+++ b/tests/test_run_scripts.py
@@ -93,7 +93,12 @@ def test_script(script_runner):
     # inner and outer script runners.
 
     result = script_runner.run(
-        ['pytest', test, f'--script-launch-mode={launch_mode}']
+        [
+            'pytest',
+            f'--rootdir={tmp_path}',
+            test,
+            f'--script-launch-mode={launch_mode}'
+        ]
     )
     assert result.success
 
@@ -256,7 +261,12 @@ def test_fail(script_runner):
         """
     )
     result = script_runner.run(
-        ['pytest', test, f'--script-launch-mode={launch_mode}']
+        [
+            'pytest',
+            f'--rootdir={tmp_path}',
+            test,
+            f'--script-launch-mode={launch_mode}'
+        ]
     )
     assert result.success != fail
     if fail:
@@ -312,7 +322,7 @@ def test_script(script_runner):
     script_runner.run(R'''{console_script}''', print_result=False)
         """
     )
-    result = script_runner.run(['pytest', '-s', test])
+    result = script_runner.run(['pytest', '-s', f'--rootdir={tmp_path}', test])
     assert result.success
     assert 'the answer is 42' not in result.stdout
     assert 'Running console script' not in result.stdout
@@ -333,7 +343,9 @@ def test_script(script_runner):
     script_runner.run(R'''{console_script}''')
         """
     )
-    result = script_runner.run(['pytest', '-s', '--hide-run-results', test])
+    result = script_runner.run(
+        ['pytest', '-s', '--hide-run-results', f'--rootdir={tmp_path}', test]
+    )
     assert result.success
     assert 'the answer is 42' not in result.stdout
     assert 'Running console script' not in result.stdout


### PR DESCRIPTION
In a Debian CI environment, several of the test suite tests failed because of an issue with pytest 8.x, as discussed in detail in https://github.com/pytest-dev/pytest/issues/11781.  In brief, if a temporary directory is created (`tmp_path` in these tests), and pytest is called with just the test file or directory path, then unless it finds a suitable configuration file, it will look for the common ancestor of the invocation directory and the test file/directory, and set that as `rootdir`.  In the Debian case, the tests are copied to a directory under `/tmp`, so the common ancestor is `/tmp`.  Then pytest searches the entire directory tree under `/tmp` for suitable tests, which causes it to crash.

The simplest fix (without figuring out a new behaviour for pytest) is to explicitly specify `rootdir` on pytest invocations.  This is what this patch does.