### PR TITLE
Modernize old workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,15 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Tox
+        run: pip install tox
+      - name: Lint with tox
+        run: tox run -e lint
+
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -22,10 +31,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install tox
     - name: Test with tox
-      run: tox run -e py,report_ci,lint
+      run: tox run -e py,report_ci
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev", "pypy3.9", "pypy3.10"]
         os: ["ubuntu-latest", "windows-latest"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -26,7 +26,7 @@ jobs:
         pip install tox
     - name: Test with tox
       run: tox run -e py,report_ci,lint
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -34,30 +34,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install build dependencies
         run: pip install --upgrade build
       - name: Build distributions
         run: python -m build
       - name: Upload packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-dist
           path: dist/*
           retention-days: 1
+          compression-level: 0
 
   publish:
     needs: [tests, package]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.ref_type == 'tag'
     environment:
       name: release
-      url: https://pypi.org/p/pytest-console-scripts
+      url: https://pypi.org/project/pytest-console-scripts/${{ github.ref_name }}/
     permissions:
       id-token: write
     steps:
       - name: Download packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-dist
           path: dist/

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.org/en/latest/
 [tox]
-envlist = clean,lint,py38,py39,py310,py311,pypy3,report
+envlist = clean,lint,py38,py39,py310,py311,py312,pypy3,report
 
 [testenv]
 deps =
@@ -9,8 +9,8 @@ deps =
 usedevelop = true
 commands = pytest tests --cov=pytest_console_scripts --cov-append --cov-report=term-missing {posargs}
 depends =
-    {py38,py39,py310,py311,pypy3}: clean
-    report: py38,py39,py310,py311,pypy3
+    {py38,py39,py310,py311,py312,pypy3}: clean
+    report: py38,py39,py310,py311,py312,pypy3
 
 [testenv:clean]
 deps = coverage
@@ -41,7 +41,6 @@ deps =
     flake8-commas
     pep8-naming
     mypy
-    types-setuptools
 
 commands =
     check-manifest --ignore *.ini,tests*,.*.yml,demo*,_version.py


### PR DESCRIPTION
Add tests for Python 3.12 3.13 and PyPy 3.10.

Publishing uses the correct URL.

Removed `types-setuptools` because there is no `setup.py` to check.

Failing CI tests were caused by installing `check-manifest` on PyPy on Windows. I couldn't convince Tox to force CPython for the lint test environment so I moved linting into a separate CI job. Linting is redundant if done more than once anyways.

Possible future task: Flake8 on Tox could be replaced with Ruff on pre-commit.