### PR TITLE
Move script_runner fixture to session scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `script_runner` is now a session-scoped fixture.
+  [#89](https://github.com/kvas-it/pytest-console-scripts/issues/89)
+
 ## [1.4.1] - 2023-05-29
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ def test_foo_bar(script_runner: ScriptRunner) -> None:
     ...
 ```
 
+Session-scoped fixtures and script_runner_factory
+-------------------------------------------------
+
+The `script_runner` fixture is session-scoped, but when tests run in multiple
+launch modes pytest may re-create it (and any fixtures depending on it) for
+each launch mode. Depending on test ordering this might effectively make it
+function-scoped. If you need a session-scoped fixture that does not get
+re-created, use `script_runner_factory` and build a runner with an explicit
+launch mode:
+
+```py
+@pytest.fixture(scope="session")
+def heavy_setup(script_runner_factory):
+    runner = script_runner_factory.make_runner("inprocess")
+    # use custom runner to do heavy setup here
+```
+
 Configuring script execution mode
 ---------------------------------
 

--- a/pytest_console_scripts/__init__.py
+++ b/pytest_console_scripts/__init__.py
@@ -111,10 +111,16 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     mode = mark_mode or option_mode or config_mode or 'inprocess'
 
     if mode in {'inprocess', 'subprocess'}:
-        metafunc.parametrize('script_launch_mode', [mode], indirect=True)
+        metafunc.parametrize(
+            'script_launch_mode', [mode], indirect=True, scope="session"
+        )
     elif mode == 'both':
-        metafunc.parametrize('script_launch_mode', ['inprocess', 'subprocess'],
-                             indirect=True)
+        metafunc.parametrize(
+            'script_launch_mode',
+            ['inprocess', 'subprocess'],
+            indirect=True,
+            scope="session",
+        )
     else:
         raise ValueError(f'Invalid script launch mode: {mode}')
 

--- a/pytest_console_scripts/__init__.py
+++ b/pytest_console_scripts/__init__.py
@@ -12,7 +12,7 @@ import sys
 import traceback
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Iterator, Sequence, Union
+from typing import Any, Callable, Final, Iterator, Sequence, Union
 from unittest import mock
 
 import pytest
@@ -234,9 +234,9 @@ class ScriptRunner:
         print_result: bool = True
     ) -> None:
         assert launch_mode in {'inprocess', 'subprocess'}
-        self.launch_mode = launch_mode
-        self.print_result = print_result
-        self.rootdir = rootdir
+        self.launch_mode: Final = launch_mode
+        self.print_result: Final = print_result
+        self.rootdir: Final = rootdir
 
     def __repr__(self) -> str:
         return f'<ScriptRunner {self.launch_mode}>'
@@ -455,19 +455,17 @@ class ScriptRunner:
         return RunResult(cp.returncode, cp.stdout, cp.stderr, print_result)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def script_launch_mode(request: pytest.FixtureRequest) -> str:
     return str(request.param)
 
 
-@pytest.fixture
-def script_cwd(tmp_path: Path) -> Path:
-    work_dir = tmp_path / 'script-cwd'
-    work_dir.mkdir()
-    return work_dir
+@pytest.fixture(scope="session")
+def script_cwd(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return tmp_path_factory.mktemp('script-cwd')
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def script_runner(
     request: pytest.FixtureRequest, script_cwd: Path, script_launch_mode: str
 ) -> ScriptRunner:


### PR DESCRIPTION
Requires its dependencies to also me moved to the session scope, `tmp_path` was function-scoped and must be replaced with `tmp_path_factory`.

Needed to work well with custom fixtures, Fixes #89

`ScriptRunner` attributes marked as `Final` to document and enforce them as read-only

I've also noticed that `rootdir` does not seem to be used anywhere, but I didn't do anything with this knowledge. `script_cwd` and `rootdir` can probably be removed.